### PR TITLE
ENH: expose `limit_to_ext` param to control which files get written 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.egg-info

--- a/datalad_osf/utils.py
+++ b/datalad_osf/utils.py
@@ -92,7 +92,7 @@ def osf_to_csv(osf_dict, csv, subset=None, limit_to_ext=None):
         for item in osf_dict['data']:
             name = item['attributes']['name']
             if limit_to_ext is not None:
-                if name.endswith(limit_to_ext):
+                if not name.endswith(limit_to_ext):
                     continue
             if item['attributes']['kind'] == 'file':
                 sha = item['attributes']['extra']['hashes']['sha256']

--- a/datalad_osf/utils.py
+++ b/datalad_osf/utils.py
@@ -66,7 +66,7 @@ def addurls_from_csv(csv, filenameformat='{path}', urlformat='{url}'):
         ifexists='overwrite')
 
 
-def osf_to_csv(osf_dict, csv, subset=None, limit_to_ext=None):
+def osf_to_csv(osf_dict, csv, subset=None, limit_to_ext='.nii.gz'):
     """Construct a CSV file from OSF metadata.
 
     Parameters
@@ -165,7 +165,7 @@ def get_osf_recursive(url, subset=None):
     return _get_osf_recursive(url, url, subset, depth=0)
 
 
-def update_recursive(key, csv=None, subset=None, limit_to_ext=None):
+def update_recursive(key, csv=None, subset=None, limit_to_ext='.nii.gz'):
     """Recursively add data from OSF project to the current datalad dataset.
 
     Parameters


### PR DESCRIPTION
fixes #1 
closes #4 

This PR consists of three contributions. I suggest to click on the specific commits to review the diffs, because there are lots of cosmetic changes on top.

1. expose a new parameter `limit_to_ext` to stop hardcoding that only `nii.gz` files get written. See: this diff: https://github.com/templateflow/datalad-osf/commit/79b83344c2ce33f4760f0b8931d34d80b4ad1455
1. add a `.gitignore` file, see this diff: https://github.com/templateflow/datalad-osf/commit/49b3162e250226bd93af5ef48445cecd482c9243
1. fix docstrings to adhere to numpy docstr style and fix pep8 issues, see this diff: https://github.com/templateflow/datalad-osf/commit/6c8859dbc2329d3c5b037453bed66ba043b8e920

Note: The PR preserves the previous behavior of datalad-osf (see https://github.com/templateflow/datalad-osf/pull/2/commits/27c5f907aefc985dba0d999549ec674c9feefb2d).
