### PR TITLE
Update utils.py to allow for .nii file extension

### DIFF
--- a/datalad_osf/utils.py
+++ b/datalad_osf/utils.py
@@ -88,7 +88,7 @@ def osf_to_csv(osf_dict, csv, subset=None):
         for item in osf_dict['data']:
             name = item['attributes']['name']
             ext = ''.join(pathlib.Path(name).suffixes)
-            if item['attributes']['kind'] == 'file' and ext == '.nii.gz':
+            if item['attributes']['kind'] == 'file' and ext == '.nii.gz' or ext == '.nii':
                 sha = item['attributes']['extra']['hashes']['sha256']
                 url = item['links']['download']
                 path = item['attributes']['materialized']


### PR DESCRIPTION
Currently, the code only allows for the download files with the extension of '.nii.gz'. However, some datasets may not have gzipped the niftis, and thus those datasets don't get downloaded.

I've added a simple 'or' statement to include non-gzipped niftis (i.e. '.nii'). Tested and it seems to work on the dataset originally giving me issues.